### PR TITLE
Consistent normalisation.

### DIFF
--- a/lib/sdrplay/sdrplay_source_c.cc
+++ b/lib/sdrplay/sdrplay_source_c.cc
@@ -237,7 +237,7 @@ int sdrplay_source_c::work( int noutput_items,
    {
       for (int i = _buf_offset; i < _dev->samplesPerPacket; i++)
       {
-         *out++ = gr_complex( float(_bufi[i]) * (1.0f/4096.0f), float(_bufq[i]) * (1.0f/4096.0f) );
+         *out++ = gr_complex( float(_bufi[i]) * (1.0f/32768.0f), float(_bufq[i]) * (1.0f/32768.0f) );
       }
       cnt -= (_dev->samplesPerPacket - _buf_offset);
    }
@@ -258,7 +258,7 @@ int sdrplay_source_c::work( int noutput_items,
       mir_sdr_ReadPacket(_bufi.data(), _bufq.data(), &sampNum, &grChanged, &rfChanged, &fsChanged);
       for (int i = 0; i < cnt; i++)
       {
-         *out++ = gr_complex( float(_bufi[i]) * (1.0f/4096.0f), float(_bufq[i]) * (1.0f/4096.0f) );
+         *out++ = gr_complex( float(_bufi[i]) * (1.0f/32768.0f), float(_bufq[i]) * (1.0f/32768.0f) );
       }
       _buf_offset = cnt;
    }


### PR DESCRIPTION
API returns sixteen bit signed samples. 1/4096 is used for the split packets at the start and end of a block, but 1/32768 is used for the bulk of the packets. That would be bad. 